### PR TITLE
Adding body to InvalidApiResponseError

### DIFF
--- a/src/api/containers.rs
+++ b/src/api/containers.rs
@@ -20,7 +20,7 @@ pub struct Container {
     pub Labels: Option<HashMap<String, String>>,
 
     #[serde(default)]
-    pub SizeRw: Option<u64>,
+    pub SizeRw: Option<i64>,
 
     #[serde(default)]
     pub SizeRootFs: u64,
@@ -42,9 +42,11 @@ pub struct HostConfig {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Mounts {
-    pub Name: String,
+    #[serde(default)]
+    pub Name: Option<String>,
     pub Source: String,
     pub Destination: String,
+    #[serde(default)]
     pub Driver: String,
     pub Mode: String,
     pub RW: bool,
@@ -143,6 +145,7 @@ pub trait Containers: DockerApiClient {
                     } else {
                         return Err(DockerApiError::InvalidApiResponseError(
                             resp.status_code,
+                            resp.body,
                         ));
                     }
                 }
@@ -240,6 +243,8 @@ pub trait Containers: DockerApiClient {
     /// Create a container from the ContainerConfig structure with the provided
     /// `name`. The response for the request is the CreateContaierResponse struct
     /// which contains the ID for the container which we created.
+    /// The image must exist locally or the API call will fail with a 404 status
+    /// code.
     fn create_container(
         &self,
         name: &str,
@@ -257,6 +262,7 @@ pub trait Containers: DockerApiClient {
         if resp.status_code != 201 {
             return Err(DockerApiError::InvalidApiResponseError(
                 resp.status_code,
+                resp.body,
             ));
         }
         match serde_json::from_str(&resp.body) {
@@ -347,6 +353,7 @@ pub trait Containers: DockerApiClient {
         if resp.status_code != 200 {
             return Err(DockerApiError::InvalidApiResponseError(
                 resp.status_code,
+                resp.body,
             ));
         }
 
@@ -372,6 +379,7 @@ pub trait Containers: DockerApiClient {
         if resp.status_code != 200 {
             return Err(DockerApiError::InvalidApiResponseError(
                 resp.status_code,
+                resp.body,
             ));
         }
 
@@ -455,6 +463,7 @@ pub trait Containers: DockerApiClient {
         } else {
             Err(DockerApiError::InvalidApiResponseError(
                 resp.status_code,
+                resp.body,
             ))
         }
     }

--- a/src/api/images.rs
+++ b/src/api/images.rs
@@ -68,6 +68,7 @@ pub trait Images: DockerApiClient {
         if resp.status_code != 200 {
             return Err(DockerApiError::InvalidApiResponseError(
                 resp.status_code,
+                resp.body,
             ));
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,9 +48,9 @@ quick_error! {
             display("Error while parsing response : {}", err)
         }
 
-        InvalidApiResponseError(status: usize) {
+        InvalidApiResponseError(status: usize, body: String) {
             description("Response from Docker API is not valid")
-            display("Invalid API response, status_code : {}", status)
+            display("Invalid API response, status_code : {}, body: {}", status, body)
         }
 
         ApiRequestError(msg: &'static str) {


### PR DESCRIPTION
Error responses coming back from the Docker API contain useful information in the body of the response, this PR is to update the error `InvalidApiResponseError` to include this information when presenting the error to the user, E.g.:

```rust
InvalidApiResponseError(404, "{\"message\":\"No such image: debian:jessie\"}")', libcore/result.rs:945:5
```

The PR also includes a few minor fixes.